### PR TITLE
Add Angular Material and refactor UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@angular/compiler": "^16.0.0",
         "@angular/core": "^16.0.0",
         "@angular/forms": "^16.2.12",
+        "@angular/material": "^16.2.14",
         "@angular/platform-browser": "^16.0.0",
         "@angular/platform-browser-dynamic": "^16.0.0",
         "@angular/router": "^16.0.0",
@@ -586,6 +587,24 @@
         "@angular/core": "16.2.12"
       }
     },
+    "node_modules/@angular/cdk": {
+      "version": "16.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-16.2.14.tgz",
+      "integrity": "sha512-n6PrGdiVeSTEmM/HEiwIyg6YQUUymZrb5afaNLGFRM5YL0Y8OBqd+XhCjb0OfD/AfgCUtedVEPwNqrfW8KzgGw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "optionalDependencies": {
+        "parse5": "^7.1.2"
+      },
+      "peerDependencies": {
+        "@angular/common": "^16.0.0 || ^17.0.0",
+        "@angular/core": "^16.0.0 || ^17.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
     "node_modules/@angular/cli": {
       "version": "16.0.6",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.0.6.tgz",
@@ -854,6 +873,71 @@
         "@angular/common": "16.2.12",
         "@angular/core": "16.2.12",
         "@angular/platform-browser": "16.2.12",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material": {
+      "version": "16.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-16.2.14.tgz",
+      "integrity": "sha512-zQIxUb23elPfiIvddqkIDYqQhAHa9ZwMblfbv+ug8bxr4D0Dw360jIarxCgMjAcLj7Ccl3GBqZMUnVeM6cjthw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/auto-init": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/banner": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/card": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/checkbox": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/chips": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/circular-progress": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/data-table": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dialog": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/drawer": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/fab": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/form-field": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/image-list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/layout-grid": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/line-ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/linear-progress": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu-surface": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/notched-outline": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/radio": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/segmented-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/select": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/slider": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/snackbar": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/switch": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-bar": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-scroller": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/textfield": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tooltip": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/top-app-bar": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "^16.0.0 || ^17.0.0",
+        "@angular/cdk": "16.2.14",
+        "@angular/common": "^16.0.0 || ^17.0.0",
+        "@angular/core": "^16.0.0 || ^17.0.0",
+        "@angular/forms": "^16.0.0 || ^17.0.0",
+        "@angular/platform-browser": "^16.0.0 || ^17.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -3466,6 +3550,808 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@material/animation": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-leRf+BcZTfC/iSigLXnYgcHAGvFVQveoJT5+2PIRdyPI/bIG7hhciRgacHRsCKC0sGya81dDblLgdkjSUemYLw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/auto-init": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/auto-init/-/auto-init-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-uxzDq7q3c0Bu1pAsMugc1Ik9ftQYQqZY+5e2ybNplT8gTImJhNt4M2mMiMHbMANk2l3UgICmUyRSomgPBWCPIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/banner": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/banner/-/banner-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-SHeVoidCUFVhXANN6MNWxK9SZoTSgpIP8GZB7kAl52BywLxtV+FirTtLXkg/8RUkxZRyRWl7HvQ0ZFZa7QQAyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/base": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Fc3vGuOf+duGo22HTRP6dHdc+MUe0VqQfWOuKrn/wXKD62m0QQR2TqJd3rRhCumH557T5QUyheW943M3E+IGfg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/button": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/button/-/button-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-3AQgwrPZCTWHDJvwgKq7Cj+BurQ4wTjDdGL+FEnIGUAjJDskwi1yzx5tW2Wf/NxIi7IoPFyOY3UB41jwMiOrnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/card": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/card/-/card-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-nPlhiWvbLmooTnBmV5gmzB0eLWSgLKsSRBYAbIBmO76Okgz1y+fQNLag+lpm/TDaHVsn5fmQJH8e0zIg0rYsQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/checkbox": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/checkbox/-/checkbox-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-4tpNnO1L0IppoMF3oeQn8F17t2n0WHB0D7mdJK9rhrujen/fLbekkIC82APB3fdGtLGg3qeNqDqPsJm1YnmrwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/chips": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/chips/-/chips-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-fqHKvE5bSWK0bXVkf57MWxZtytGqYBZvvHIOs4JI9HPHEhaJy4CpSw562BEtbm3yFxxALoQknvPW2KYzvADnmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/checkbox": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/circular-progress": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/circular-progress/-/circular-progress-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Lxe8BGAxQwCQqrLhrYrIP0Uok10h7aYS3RBXP41ph+5GmwJd5zdyE2t93qm2dyThvU6qKuXw9726Dtq/N+wvZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/progress-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/data-table": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/data-table/-/data-table-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-j/7qplT9+sUpfe4pyWhPbl01qJA+OoNAG3VMJruBBR461ZBKyTi7ssKH9yksFGZ8eCEPkOsk/+kDxsiZvRWkeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/checkbox": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/linear-progress": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/select": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/density": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/density/-/density-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Zt3u07fXrBWLW06Tl5fgvjicxNQMkFdawLyNTzZ5TvbXfVkErILLePwwGaw8LNcvzqJP6ABLA8jiR+sKNoJQCg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/dialog": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-o+9a/fmwJ9+gY3Z/uhj/PMVJDq7it1NTWKJn2GwAKdB+fDkT4hb9qEdcxMPyvJJ5ups+XiKZo03+tZrD+38c1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/dom": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-ly78R7aoCJtundSUu0UROU+5pQD5Piae0Y1MkN6bs0724azeazX1KeXFeaf06JOXnlr5/41ol+fSUPowjoqnOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/drawer": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/drawer/-/drawer-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-PFL4cEFnt7VTxDsuspFVNhsFDYyumjU0VWfj3PWB7XudsEfQ3lo85D3HCEtTTbRsCainGN8bgYNDNafLBqiigw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/elevation": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Ro+Pk8jFuap+T0B0shA3xI1hs2b89dNQ2EIPCNjNMp87emHKAzJfhKb7EZGIwv3+gFLlVaLyIVkb94I89KLsyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/fab": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/fab/-/fab-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-dvU0KWMRglwJEQwmQtFAmJcAjzg9VFF6Aqj78bJYu/DAIGFJ1VTTTSgoXM/XCm1YyQEZ7kZRvxBO37CH54rSDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/feature-targeting": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-wkDjVcoVEYYaJvun28IXdln/foLgPD7n9ZC9TY76GErGCwTq+HWpU6wBAAk+ePmpRFDayw4vI4wBlaWGxLtysQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/floating-label": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-bUWPtXzZITOD/2mkvLkEPO1ngDWmb74y0Kgbz6llHLOQBtycyJIpuoQJ1q2Ez0NM/tFLwPphhAgRqmL3YQ/Kzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/focus-ring": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/focus-ring/-/focus-ring-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-cZHThVose3GvAlJzpJoBI1iqL6d1/Jj9hXrR+r8Mwtb1hBIUEG3hxfsRd4vGREuzROPlf0OgNf/V+YHoSwgR5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0"
+      }
+    },
+    "node_modules/@material/form-field": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/form-field/-/form-field-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-+JFXy5X44Gue1CbZZAQ6YejnI203lebYwL0i6k0ylDpWHEOdD5xkF2PyHR28r9/65Ebcbwbff6q7kI1SGoT7MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/icon-button": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/icon-button/-/icon-button-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-1a0MHgyIwOs4RzxrVljsqSizGYFlM1zY2AZaLDsgT4G3kzsplTx8HZQ022GpUCjAygW+WLvg4z1qAhQHvsbqlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/image-list": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/image-list/-/image-list-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-WKWmiYap2iu4QdqmeUSliLlN4O2Ueqa0OuVAYHn/TCzmQ2xmnhZ1pvDLbs6TplpOmlki7vFfe+aSt5SU9gwfOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/layout-grid": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/layout-grid/-/layout-grid-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-5GqmT6oTZhUGWIb+CLD0ZNyDyTiJsr/rm9oRIi3+vCujACwxFkON9tzBlZohdtFS16nuzUusthN6Jt9UrJcN6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/line-ripple": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-8S30WXEuUdgDdBulzUDlPXD6qMzwCX9SxYb5mGDYLwl199cpSGdXHtGgEcCjokvnpLhdZhcT1Dsxeo1g2Evh5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/linear-progress": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/linear-progress/-/linear-progress-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-6EJpjrz6aoH2/gXLg9iMe0yF2C42hpQyZoHpmcgTLKeci85ktDvJIjwup8tnk8ULQyFiGiIrhXw2v2RSsiFjvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/progress-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/list": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/list/-/list-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-TQ1ppqiCMQj/P7bGD4edbIIv4goczZUoiUAaPq/feb1dflvrFMzYqJ7tQRRCyBL8nRhJoI2x99tk8Q2RXvlGUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/menu": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/menu/-/menu-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-IlAh61xzrzxXs38QZlt74UYt8J431zGznSzDtB1Fqs6YFNd11QPKoiRXn1J2Qu/lUxbFV7i8NBKMCKtia0n6/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu-surface": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/menu-surface": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/menu-surface/-/menu-surface-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-dMtSPN+olTWE+08M5qe4ea1IZOhVryYqzK0Gyb2u1G75rSArUxCOB5rr6OC/ST3Mq3RS6zGuYo7srZt4534K9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/notched-outline": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-WuurMg44xexkvLTBTnsO0A+qnzFjpcPdvgWBGstBepYozsvSF9zJGdb1x7Zv1MmqbpYh/Ohnuxtb/Y3jOh6irg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/progress-indicator": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/progress-indicator/-/progress-indicator-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-uOnsvqw5F2fkeTnTl4MrYzjI7KCLmmLyZaM0cgLNuLsWVlddQE+SGMl28tENx7DUK3HebWq0FxCP8f25LuDD+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/radio": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/radio/-/radio-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-ehzOK+U1IxQN+OQjgD2lsnf1t7t7RAwQzeO6Czkiuid29ookYbQynWuLWk7NW8H8ohl7lnmfqTP1xSNkkL/F0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/ripple": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-JfLW+g3GMVDv4cruQ19+HUxpKVdWCldFlIPw1UYezz2h3WTNDy05S3uP2zUdXzZ01C3dkBFviv4nqZ0GCT16MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/rtl": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-SkKLNLFp5QtG7/JEFg9R92qq4MzTcZ5As6sWbH7rRg6ahTHoJEuqE+pOb9Vrtbj84k5gtX+vCYPvCILtSlr2uw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/segmented-button": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/segmented-button/-/segmented-button-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-YDwkCWP9l5mIZJ7pZJZ2hMDxfBlIGVJ+deNzr8O+Z7/xC5LGXbl4R5aPtUVHygvXAXxpf5096ZD+dSXzYzvWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/select": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/select/-/select-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-unfOWVf7T0sixVG+3k3RTuATfzqvCF6QAzA6J9rlCh/Tq4HuIBNDdV4z19IVu4zwmgWYxY0iSvqWUvdJJYwakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/line-ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu-surface": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/notched-outline": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/shape": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Dsvr771ZKC46ODzoixLdGwlLEQLfxfLrtnRojXABoZf5G3o9KtJU+J+5Ld5aa960OAsCzzANuaub4iR88b1guA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/slider": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/slider/-/slider-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-3AEu+7PwW4DSNLndue47dh2u7ga4hDJRYmuu7wnJCIWJBnLCkp6C92kNc4Rj5iQY2ftJio5aj1gqryluh5tlYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/snackbar": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/snackbar/-/snackbar-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-TwwQSYxfGK6mc03/rdDamycND6o+1p61WNd7ElZv1F1CLxB4ihRjbCoH7Qo+oVDaP8CTpjeclka+24RLhQq0mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/switch": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/switch/-/switch-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-OjUjtT0kRz1ASAsOS+dNzwMwvsjmqy5edK57692qmrP6bL4GblFfBDoiNJ6t0AN4OaKcmL5Hy/xNrTdOZW7Qqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab/-/tab-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-s/L9otAwn/pZwVQZBRQJmPqYeNbjoEbzbjMpDQf/VBG/6dJ+aP03ilIBEkqo8NVnCoChqcdtVCoDNRtbU+yp6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-bar": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-bar/-/tab-bar-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Xmtq0wJGfu5k+zQeFeNsr4bUKv7L+feCmUp/gsapJ655LQKMXOUQZtSv9ZqWOfrCMy55hoF1CzGFV+oN3tyWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-scroller": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-indicator": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-indicator/-/tab-indicator-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-despCJYi1GrDDq7F2hvLQkObHnSLZPPDxnOzU16zJ6FNYvIdszgfzn2HgAZ6pl5hLOexQ8cla6cAqjTDuaJBhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-scroller": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-scroller/-/tab-scroller-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-QWHG/EWxirj4V9u2IHz+OSY9XCWrnNrPnNgEufxAJVUKV/A8ma1DYeFSQqxhX709R8wKGdycJksg0Flkl7Gq7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/textfield": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-R3qRex9kCaZIAK8DuxPnVC42R0OaW7AB7fsFknDKeTeVQvRcbnV8E+iWSdqTiGdsi6QQHifX8idUrXw+O45zPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/line-ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/notched-outline": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/theme": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-CpUwXGE0dbhxQ45Hu9r9wbJtO/MAlv5ER4tBHA9tp/K+SU+lDgurBE2touFMg5INmdfVNtdumxb0nPPLaNQcUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tokens": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-nbEuGj05txWz6ZMUanpM47SaAD7soyjKILR+XwDell9Zg3bGhsnexCNXPEz2fD+YgomS+jM5XmIcaJJHg/H93Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0"
+      }
+    },
+    "node_modules/@material/tooltip": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tooltip/-/tooltip-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-UzuXp0b9NuWuYLYpPguxrjbJnCmT/Cco8CkjI/6JajxaeA3o2XEBbQfRMTq8PTafuBjCHTc0b0mQY7rtxUp1Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/top-app-bar": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/top-app-bar/-/top-app-bar-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-vJWjsvqtdSD5+yQ/9vgoBtBSCvPJ5uF/DVssv8Hdhgs1PYaAcODUi77kdi0+sy/TaWyOsTkQixqmwnFS16zesA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/touch-target": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-AqYh9fjt+tv4ZE0C6MeYHblS2H+XwLbDl2mtyrK0DOEnCVQk5/l5ImKDfhrUdFWHvS4a5nBM4AA+sa7KaroLoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/typography": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-CKsG1zyv34AKPNyZC8olER2OdPII64iR2SzQjpqh1UUvmIFiMPk23LvQ1OnC5aCB14pOXzmVgvJt31r9eNdZ6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
     },
     "node_modules/@ngtools/webpack": {
       "version": "16.2.16",
@@ -10651,7 +11537,7 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -10692,7 +11578,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -11754,6 +12640,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/safevalues": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/safevalues/-/safevalues-0.3.4.tgz",
+      "integrity": "sha512-LRneZZRXNgjzwG4bDQdOTSbze3fHm1EAKN/8bePxnlEZiBmkYEDggaHbuvHI9/hoqHbGfsEA7tWS9GhYHZBBsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/sass": {
       "version": "1.64.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@angular/compiler": "^16.0.0",
     "@angular/core": "^16.0.0",
     "@angular/forms": "^16.2.12",
+    "@angular/material": "^16.2.14",
     "@angular/platform-browser": "^16.0.0",
     "@angular/platform-browser-dynamic": "^16.0.0",
     "@angular/router": "^16.0.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule } from '@angular/forms';
 
 import { AppRoutingModule } from './app-routing.module';
@@ -22,6 +23,7 @@ import { NotificationService } from './services/notification.service';
   ],
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     AppRoutingModule,
     FormsModule
   ],

--- a/src/app/features/auth/components/login/login.component.html
+++ b/src/app/features/auth/components/login/login.component.html
@@ -1,122 +1,55 @@
 <div class="auth-container">
-  <div class="auth-card">
-    <!-- Header Section -->
-    <div class="auth-header">
-      <div class="logo">
-        <div class="logo-icon">
-          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3 3h18v4H3V3zm0 6h18v4H3V9zm0 6h18v4H3v-4z" fill="currentColor"/>
-            <path d="M21 5h-6v2h6V5zm0 6h-6v2h6v-2zm0 6h-6v2h6v-2z" fill="#FF6600"/>
-          </svg>
-        </div>
-        <div class="logo-text">
-          <span class="brand-name">FedEx</span>
-          <span class="brand-suffix">Tracking</span>
-        </div>
-      </div>
-      <h1>Connexion Sécurisée</h1>
-      <p>Connectez-vous pour suivre vos colis et gérer vos expéditions</p>
-    </div>
+  <mat-card class="auth-card">
+    <mat-card-header>
+      <div mat-card-avatar class="logo-icon"></div>
+      <mat-card-title>Connexion Sécurisée</mat-card-title>
+      <mat-card-subtitle>Connectez-vous pour suivre vos colis et gérer vos expéditions</mat-card-subtitle>
+    </mat-card-header>
 
-    <!-- Form Section -->
-    <div class="auth-form">
+    <mat-card-content>
       <form [formGroup]="loginForm" (ngSubmit)="onSubmit()">
-        <!-- Email Field -->
-        <div class="form-field">
-          <label for="email">Adresse email</label>
-          <div class="input-group">
-            <input 
-              type="email" 
-              id="email"
-              formControlName="email"
-              placeholder="votre.email@exemple.com"
-              autocomplete="email"
-              [class.error]="loginForm.get('email')?.invalid && loginForm.get('email')?.touched">
-            <span class="icon">📧</span>
-          </div>
-          <div class="error-message" *ngIf="loginForm.get('email')?.hasError('required') && loginForm.get('email')?.touched">
-            L'email est requis
-          </div>
-          <div class="error-message" *ngIf="loginForm.get('email')?.hasError('email') && loginForm.get('email')?.touched">
-            Veuillez entrer un email valide
-          </div>
-        </div>
+        <mat-form-field appearance="fill" class="full-width">
+          <mat-label>Adresse email</mat-label>
+          <input matInput type="email" formControlName="email" placeholder="votre.email@exemple.com" autocomplete="email">
+          <mat-error *ngIf="loginForm.get('email')?.hasError('required')">L'email est requis</mat-error>
+          <mat-error *ngIf="loginForm.get('email')?.hasError('email')">Veuillez entrer un email valide</mat-error>
+        </mat-form-field>
 
-        <!-- Password Field -->
-        <div class="form-field">
-          <label for="password">Mot de passe</label>
-          <div class="input-group">
-            <input 
-              [type]="hidePassword ? 'password' : 'text'"
-              id="password"
-              formControlName="password"
-              placeholder="Votre mot de passe"
-              autocomplete="current-password"
-              [class.error]="loginForm.get('password')?.invalid && loginForm.get('password')?.touched">
-            <button 
-              type="button"
-              class="toggle-password"
-              (click)="hidePassword = !hidePassword">
-              {{ hidePassword ? '👁️' : '🙈' }}
-            </button>
-          </div>
-          <div class="error-message" *ngIf="loginForm.get('password')?.hasError('required') && loginForm.get('password')?.touched">
-            Le mot de passe est requis
-          </div>
-        </div>
+        <mat-form-field appearance="fill" class="full-width">
+          <mat-label>Mot de passe</mat-label>
+          <input matInput [type]="hidePassword ? 'password' : 'text'" formControlName="password" placeholder="Votre mot de passe" autocomplete="current-password">
+          <button mat-icon-button matSuffix type="button" (click)="hidePassword = !hidePassword">
+            <mat-icon>{{ hidePassword ? 'visibility' : 'visibility_off' }}</mat-icon>
+          </button>
+          <mat-error *ngIf="loginForm.get('password')?.hasError('required')">Le mot de passe est requis</mat-error>
+        </mat-form-field>
 
-        <!-- Remember Me & Forgot Password -->
-        <div class="auth-options">
-          <label class="checkbox-label">
-            <input type="checkbox" formControlName="rememberMe">
-            <span>Se souvenir de moi</span>
-          </label>
-          <a routerLink="/auth/forgot-password" class="forgot-password">
-            Mot de passe oublié ?
-          </a>
-        </div>
+        <mat-checkbox formControlName="rememberMe">Se souvenir de moi</mat-checkbox>
+        <a routerLink="/auth/forgot-password" class="forgot-password">Mot de passe oublié ?</a>
 
-        <!-- Submit Button -->
-        <button 
-          type="submit" 
-          class="auth-submit"
-          [disabled]="!loginForm.valid || isLoading">
+        <button mat-raised-button color="primary" type="submit" class="auth-submit" [disabled]="!loginForm.valid || isLoading">
           <span *ngIf="!isLoading">Se connecter</span>
           <span *ngIf="isLoading">Connexion en cours...</span>
         </button>
 
-        <!-- Divider -->
         <div class="divider">
-          <hr>
-          <span>ou</span>
-          <hr>
+          <hr><span>ou</span><hr>
         </div>
 
-        <!-- Google Login -->
-        <button 
-          type="button" 
-          class="google-btn"
-          (click)="loginWithGoogle()"
-          [disabled]="isLoading">
-          <svg width="20" height="20" viewBox="0 0 24 24" class="google-icon">
-            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-          </svg>
+        <button mat-stroked-button type="button" class="google-btn" (click)="loginWithGoogle()" [disabled]="isLoading">
+          <mat-icon svgIcon="google" class="google-icon"></mat-icon>
           Continuer avec Google
         </button>
       </form>
-    </div>
+    </mat-card-content>
 
-    <!-- Footer -->
-    <div class="auth-footer">
-      <p>Vous n'avez pas de compte ? 
+    <mat-card-actions class="auth-footer">
+      <p>Vous n'avez pas de compte ?
         <a routerLink="/auth/register">Créer un compte</a>
       </p>
       <p class="help-text">
         Besoin d'aide ? <a href="mailto:support@fedex.com">Contactez le support</a>
       </p>
-    </div>
-  </div>
+    </mat-card-actions>
+  </mat-card>
 </div>

--- a/src/app/features/auth/components/login/login.component.ts
+++ b/src/app/features/auth/components/login/login.component.ts
@@ -2,6 +2,12 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatIconModule } from '@angular/material/icon';
+import { MatCardModule } from '@angular/material/card';
 
 // TODO: Backend - Create Login Interface
 /*
@@ -83,7 +89,13 @@ POST /api/auth/google/login
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    RouterModule
+    RouterModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatCheckboxModule,
+    MatIconModule,
+    MatCardModule
   ],
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss']

--- a/src/app/features/tracking/components/tracking-search/tracking-search.component.html
+++ b/src/app/features/tracking/components/tracking-search/tracking-search.component.html
@@ -6,25 +6,13 @@
   
   <div class="search-form-container">
     <form class="search-form" (submit)="onSearch($event)">
-      <div class="input-group">
-        <div class="input-icon">
-          <i class="fas fa-search"></i>
-        </div>
-        <input 
-          type="text" 
-          class="search-input" 
-          [(ngModel)]="trackingNumber" 
-          [ngModelOptions]="{standalone: true}"
-          placeholder="Entrez le numéro de suivi (ex: GLX123456789)" 
-          autocomplete="off"
-          aria-label="Numéro de suivi"
-          required
-        >
-        <button type="submit" class="search-button" [disabled]="!trackingNumber">
-          <span class="button-text">Suivre</span>
-          <i class="fas fa-arrow-right"></i>
-        </button>
-      </div>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Numéro de suivi</mat-label>
+        <input matInput type="text" [(ngModel)]="trackingNumber" [ngModelOptions]="{standalone: true}" placeholder="Entrez le numéro de suivi (ex: GLX123456789)" autocomplete="off" required>
+      </mat-form-field>
+      <button mat-raised-button color="primary" type="submit" [disabled]="!trackingNumber">
+        Suivre
+      </button>
       <div class="search-example">
         Exemple: <span class="example-number" (click)="useExampleNumber()">GLX123456789</span>
       </div>

--- a/src/app/features/tracking/components/tracking-search/tracking-search.component.ts
+++ b/src/app/features/tracking/components/tracking-search/tracking-search.component.ts
@@ -1,7 +1,20 @@
 import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
 
 @Component({
   selector: 'app-tracking-search',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule
+  ],
   templateUrl: './tracking-search.component.html',
   styleUrls: ['./tracking-search.component.scss']
 })

--- a/src/app/shared/components/navbar/navbar.component.html
+++ b/src/app/shared/components/navbar/navbar.component.html
@@ -1,95 +1,15 @@
-<header class="header">
-    <nav class="navbar">
-      <a class="navbar__logo" routerLink="/">FedEx</a>
-  
-      <button class="navbar__toggle" (click)="toggleMobileMenu()">
-        <i class="fas" [ngClass]="{'fa-bars': !isMobileMenuOpen, 'fa-times': isMobileMenuOpen}"></i>
-      </button>
-  
-      <ul class="navbar__menu" [class.active]="isMobileMenuOpen">
-        <li><a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">Home</a></li>
-  
-        <li class="dropdown">
-          <a class="dropdown-toggle" (click)="toggleDropdown($event, 'tracking')">
-            Tracking <i class="fas fa-chevron-down"></i>
-          </a>
-          <ul class="dropdown__menu" [class.show]="activeDropdown === 'tracking'">
-            <li>
-              <h4>Tracking ID</h4>
-              <div class="tracking-input-group">
-                <input type="text" [(ngModel)]="quickTrackingNumber" placeholder="Insert Tracking ID Number" />
-                <button class="btn-track" (click)="quickTrack()">
-                  TRACK <i class="fas fa-arrow-right"></i>
-                </button>
-              </div>
-            </li>
-            <li><hr /></li>
-            <li>
-              <a routerLink="/tracking" [queryParams]="{type: 'advanced'}">
-                Advanced Shipment Tracking
-              </a>
-            </li>
-            <li>
-              <a routerLink="/advanced-tracking">
-                Advanced Shipment Management
-              </a>
-            </li>
-            <li>
-              <a routerLink="/tracking" [queryParams]="{type: 'mobile'}">
-                Track by Mobile
-              </a>
-            </li>
-            <li>
-              <a routerLink="/tracking">
-                <strong>All Tracking Services</strong>
-              </a>
-            </li>
-          </ul>
-        </li>
-  
-        <li>
-          <a routerLink="/history" routerLinkActive="active">History</a>
-        </li>
-  
-        <li class="dropdown">
-          <a class="dropdown-toggle" (click)="toggleDropdown($event, 'help')">
-            Help <i class="fas fa-chevron-down"></i>
-          </a>
-          <ul class="dropdown__menu" [class.show]="activeDropdown === 'help'">
-            <li><a routerLink="/help" fragment="advice">Advice</a></li>
-            <li><a routerLink="/help" fragment="tools">Tracking Tools</a></li>
-            <li><a routerLink="/help" fragment="faq">Tracking FAQs</a></li>
-            <li><a routerLink="/help" fragment="contact">Contact Us</a></li>
-          </ul>
-        </li>
-  
-        <li>
-          <a routerLink="/about" routerLinkActive="active">About</a>
-        </li>
-        <li>
-          <a routerLink="/find-location" routerLinkActive="active">Find Location</a>
-        </li>
-  
-        <li>
-          <a routerLink="/notifications" routerLinkActive="active">
-            <i class="fas fa-bell"></i>
-            <span class="notification-badge" *ngIf="notificationCount > 0">{{ notificationCount }}</span>
-          </a>
-        </li>
-  
-        <li>
-          <a routerLink="/auth/login" routerLinkActive="active">
-            <i class="fas fa-user-circle"></i> Login/Register
-          </a>
-        </li>
-      </ul>
-  
-      <div class="navbar__search">
-        <button class="search-btn" (click)="toggleSearch()">
-          <i class="fas fa-search"></i>
-        </button>
-        <input *ngIf="showSearch" type="text" class="search-input" placeholder="Rechercher..." />
-      </div>
-    </nav>
-  </header>
-  
+<mat-toolbar color="primary" class="navbar">
+  <span class="navbar__logo" routerLink="/">FedEx</span>
+  <span class="spacer"></span>
+  <button mat-button routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">Home</button>
+  <button mat-button routerLink="/history" routerLinkActive="active">History</button>
+  <button mat-button routerLink="/help" routerLinkActive="active">Help</button>
+  <button mat-icon-button routerLink="/notifications" routerLinkActive="active">
+    <mat-icon>notifications</mat-icon>
+    <span class="notification-badge" *ngIf="notificationCount > 0">{{ notificationCount }}</span>
+  </button>
+  <button mat-button routerLink="/auth/login" routerLinkActive="active">
+    <mat-icon>account_circle</mat-icon>
+    Login/Register
+  </button>
+</mat-toolbar>

--- a/src/app/shared/components/navbar/navbar.component.scss
+++ b/src/app/shared/components/navbar/navbar.component.scss
@@ -19,6 +19,10 @@
   margin: 0 auto;
   position: relative;
 
+  .spacer {
+    flex: 1 1 auto;
+  }
+
   &__logo {
     font-size: 1.5rem;
     font-weight: bold;

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -2,6 +2,9 @@ import { Component, OnInit, HostListener, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 import { Router, NavigationEnd } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
@@ -9,7 +12,14 @@ import { filter } from 'rxjs/operators';
 @Component({
   selector: 'app-navbar',
   standalone: true,
-  imports: [CommonModule, RouterModule, FormsModule],
+  imports: [
+    CommonModule,
+    RouterModule,
+    FormsModule,
+    MatToolbarModule,
+    MatButtonModule,
+    MatIconModule
+  ],
   templateUrl: './navbar.component.html',
   styleUrls: ['./navbar.component.scss']
 })

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,7 @@
 /* You can add global styles to this file, and also import other style files */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 @import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css');
+@import '@angular/material/prebuilt-themes/indigo-pink.css';
 
 /* Variables CSS globales */
 :root {


### PR DESCRIPTION
## Summary
- install `@angular/material`
- enable `BrowserAnimationsModule`
- replace login form markup with Material components
- convert search form and navbar to Material
- import Material theme

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_684b7d9344d4832e94d9ce27e4ff3f0c