### PR TITLE
Improve form accessibility

### DIFF
--- a/src/app/features/auth/components/email-verification/email-verification.component.html
+++ b/src/app/features/auth/components/email-verification/email-verification.component.html
@@ -23,19 +23,35 @@
         <div class="form-field">
           <label for="verificationCode">Code de vérification</label>
           <div class="code-input-container">
-            <input 
-              type="text" 
+            <input
+              type="text"
               id="verificationCode"
               formControlName="verificationCode"
               placeholder="123456"
               maxlength="6"
               class="code-input"
-              [class.error]="verificationForm.get('verificationCode')?.invalid && verificationForm.get('verificationCode')?.touched">
+              [class.error]="verificationForm.get('verificationCode')?.invalid && verificationForm.get('verificationCode')?.touched"
+              [attr.aria-invalid]="verificationForm.get('verificationCode')?.invalid && verificationForm.get('verificationCode')?.touched"
+              [attr.aria-describedby]="
+                verificationForm.get('verificationCode')?.hasError('required') && verificationForm.get('verificationCode')?.touched
+                  ? 'code-required'
+                  : verificationForm.get('verificationCode')?.hasError('pattern') && verificationForm.get('verificationCode')?.touched
+                    ? 'code-format'
+                    : null
+              ">
           </div>
-          <div class="error-message" *ngIf="verificationForm.get('verificationCode')?.hasError('required') && verificationForm.get('verificationCode')?.touched">
+          <div
+            class="error-message"
+            id="code-required"
+            *ngIf="verificationForm.get('verificationCode')?.hasError('required') && verificationForm.get('verificationCode')?.touched"
+          >
             Le code de vérification est requis
           </div>
-          <div class="error-message" *ngIf="verificationForm.get('verificationCode')?.hasError('pattern') && verificationForm.get('verificationCode')?.touched">
+          <div
+            class="error-message"
+            id="code-format"
+            *ngIf="verificationForm.get('verificationCode')?.hasError('pattern') && verificationForm.get('verificationCode')?.touched"
+          >
             Le code doit contenir exactement 6 chiffres
           </div>
         </div>

--- a/src/app/features/auth/components/forgot-password/forgot-password.component.html
+++ b/src/app/features/auth/components/forgot-password/forgot-password.component.html
@@ -46,19 +46,35 @@
         <div class="form-field">
           <label for="email">Adresse email</label>
           <div class="input-group">
-            <input 
-              type="email" 
+            <input
+              type="email"
               id="email"
               formControlName="email"
               placeholder="Votre adresse email"
               autocomplete="email"
-              [class.error]="forgotPasswordForm.get('email')?.invalid && forgotPasswordForm.get('email')?.touched">
+              [class.error]="forgotPasswordForm.get('email')?.invalid && forgotPasswordForm.get('email')?.touched"
+              [attr.aria-invalid]="forgotPasswordForm.get('email')?.invalid && forgotPasswordForm.get('email')?.touched"
+              [attr.aria-describedby]="
+                forgotPasswordForm.get('email')?.hasError('required') && forgotPasswordForm.get('email')?.touched
+                  ? 'fp-email-required'
+                  : forgotPasswordForm.get('email')?.hasError('email') && forgotPasswordForm.get('email')?.touched
+                    ? 'fp-email-format'
+                    : null
+              ">
             <span class="icon">📧</span>
           </div>
-          <div class="error-message" *ngIf="forgotPasswordForm.get('email')?.hasError('required') && forgotPasswordForm.get('email')?.touched">
+          <div
+            class="error-message"
+            id="fp-email-required"
+            *ngIf="forgotPasswordForm.get('email')?.hasError('required') && forgotPasswordForm.get('email')?.touched"
+          >
             L'email est requis
           </div>
-          <div class="error-message" *ngIf="forgotPasswordForm.get('email')?.hasError('email') && forgotPasswordForm.get('email')?.touched">
+          <div
+            class="error-message"
+            id="fp-email-format"
+            *ngIf="forgotPasswordForm.get('email')?.hasError('email') && forgotPasswordForm.get('email')?.touched"
+          >
             Veuillez entrer un email valide
           </div>
         </div>

--- a/src/app/features/auth/components/login/login.component.html
+++ b/src/app/features/auth/components/login/login.component.html
@@ -25,19 +25,35 @@
         <div class="form-field">
           <label for="email">Adresse email</label>
           <div class="input-group">
-            <input 
-              type="email" 
+            <input
+              type="email"
               id="email"
               formControlName="email"
               placeholder="votre.email@exemple.com"
               autocomplete="email"
-              [class.error]="loginForm.get('email')?.invalid && loginForm.get('email')?.touched">
+              [class.error]="loginForm.get('email')?.invalid && loginForm.get('email')?.touched"
+              [attr.aria-invalid]="loginForm.get('email')?.invalid && loginForm.get('email')?.touched"
+              [attr.aria-describedby]="
+                loginForm.get('email')?.hasError('required') && loginForm.get('email')?.touched
+                  ? 'email-required'
+                  : loginForm.get('email')?.hasError('email') && loginForm.get('email')?.touched
+                    ? 'email-format'
+                    : null
+              ">
             <span class="icon">📧</span>
           </div>
-          <div class="error-message" *ngIf="loginForm.get('email')?.hasError('required') && loginForm.get('email')?.touched">
+          <div
+            class="error-message"
+            id="email-required"
+            *ngIf="loginForm.get('email')?.hasError('required') && loginForm.get('email')?.touched"
+          >
             L'email est requis
           </div>
-          <div class="error-message" *ngIf="loginForm.get('email')?.hasError('email') && loginForm.get('email')?.touched">
+          <div
+            class="error-message"
+            id="email-format"
+            *ngIf="loginForm.get('email')?.hasError('email') && loginForm.get('email')?.touched"
+          >
             Veuillez entrer un email valide
           </div>
         </div>
@@ -46,13 +62,15 @@
         <div class="form-field">
           <label for="password">Mot de passe</label>
           <div class="input-group">
-            <input 
+            <input
               [type]="hidePassword ? 'password' : 'text'"
               id="password"
               formControlName="password"
               placeholder="Votre mot de passe"
               autocomplete="current-password"
-              [class.error]="loginForm.get('password')?.invalid && loginForm.get('password')?.touched">
+              [class.error]="loginForm.get('password')?.invalid && loginForm.get('password')?.touched"
+              [attr.aria-invalid]="loginForm.get('password')?.invalid && loginForm.get('password')?.touched"
+              [attr.aria-describedby]="loginForm.get('password')?.hasError('required') && loginForm.get('password')?.touched ? 'password-required' : null">
             <button 
               type="button"
               class="toggle-password"
@@ -60,7 +78,11 @@
               {{ hidePassword ? '👁️' : '🙈' }}
             </button>
           </div>
-          <div class="error-message" *ngIf="loginForm.get('password')?.hasError('required') && loginForm.get('password')?.touched">
+          <div
+            class="error-message"
+            id="password-required"
+            *ngIf="loginForm.get('password')?.hasError('required') && loginForm.get('password')?.touched"
+          >
             Le mot de passe est requis
           </div>
         </div>

--- a/src/app/features/auth/components/register/register.component.html
+++ b/src/app/features/auth/components/register/register.component.html
@@ -28,16 +28,22 @@
           <div class="form-field half-width">
             <label for="firstName">Prénom</label>
             <div class="input-group">
-              <input 
-                type="text" 
+              <input
+                type="text"
                 id="firstName"
                 formControlName="firstName"
                 placeholder="Jean"
                 autocomplete="given-name"
-                [class.error]="registerForm.get('firstName')?.invalid && registerForm.get('firstName')?.touched">
+                [class.error]="registerForm.get('firstName')?.invalid && registerForm.get('firstName')?.touched"
+                [attr.aria-invalid]="registerForm.get('firstName')?.invalid && registerForm.get('firstName')?.touched"
+                [attr.aria-describedby]="registerForm.get('firstName')?.hasError('required') && registerForm.get('firstName')?.touched ? 'firstName-required' : null">
               <span class="icon">👤</span>
             </div>
-            <div class="error-message" *ngIf="registerForm.get('firstName')?.hasError('required') && registerForm.get('firstName')?.touched">
+            <div
+              class="error-message"
+              id="firstName-required"
+              *ngIf="registerForm.get('firstName')?.hasError('required') && registerForm.get('firstName')?.touched"
+            >
               Le prénom est requis
             </div>
           </div>
@@ -45,15 +51,21 @@
           <div class="form-field half-width">
             <label for="lastName">Nom</label>
             <div class="input-group">
-              <input 
-                type="text" 
+              <input
+                type="text"
                 id="lastName"
                 formControlName="lastName"
                 placeholder="Dupont"
                 autocomplete="family-name"
-                [class.error]="registerForm.get('lastName')?.invalid && registerForm.get('lastName')?.touched">
+                [class.error]="registerForm.get('lastName')?.invalid && registerForm.get('lastName')?.touched"
+                [attr.aria-invalid]="registerForm.get('lastName')?.invalid && registerForm.get('lastName')?.touched"
+                [attr.aria-describedby]="registerForm.get('lastName')?.hasError('required') && registerForm.get('lastName')?.touched ? 'lastName-required' : null">
             </div>
-            <div class="error-message" *ngIf="registerForm.get('lastName')?.hasError('required') && registerForm.get('lastName')?.touched">
+            <div
+              class="error-message"
+              id="lastName-required"
+              *ngIf="registerForm.get('lastName')?.hasError('required') && registerForm.get('lastName')?.touched"
+            >
               Le nom est requis
             </div>
           </div>
@@ -63,19 +75,35 @@
         <div class="form-field">
           <label for="email">Adresse email</label>
           <div class="input-group">
-            <input 
-              type="email" 
+            <input
+              type="email"
               id="email"
               formControlName="email"
               placeholder="jean.dupont@exemple.com"
               autocomplete="email"
-              [class.error]="registerForm.get('email')?.invalid && registerForm.get('email')?.touched">
+              [class.error]="registerForm.get('email')?.invalid && registerForm.get('email')?.touched"
+              [attr.aria-invalid]="registerForm.get('email')?.invalid && registerForm.get('email')?.touched"
+              [attr.aria-describedby]="
+                registerForm.get('email')?.hasError('required') && registerForm.get('email')?.touched
+                  ? 'reg-email-required'
+                  : registerForm.get('email')?.hasError('email') && registerForm.get('email')?.touched
+                    ? 'reg-email-format'
+                    : null
+              ">
             <span class="icon">📧</span>
           </div>
-          <div class="error-message" *ngIf="registerForm.get('email')?.hasError('required') && registerForm.get('email')?.touched">
+          <div
+            class="error-message"
+            id="reg-email-required"
+            *ngIf="registerForm.get('email')?.hasError('required') && registerForm.get('email')?.touched"
+          >
             L'email est requis
           </div>
-          <div class="error-message" *ngIf="registerForm.get('email')?.hasError('email') && registerForm.get('email')?.touched">
+          <div
+            class="error-message"
+            id="reg-email-format"
+            *ngIf="registerForm.get('email')?.hasError('email') && registerForm.get('email')?.touched"
+          >
             Veuillez entrer un email valide
           </div>
         </div>
@@ -84,13 +112,15 @@
         <div class="form-field">
           <label for="password">Mot de passe</label>
           <div class="input-group">
-            <input 
+            <input
               [type]="hidePassword ? 'password' : 'text'"
               id="password"
               formControlName="password"
               placeholder="Créez un mot de passe sécurisé"
               autocomplete="new-password"
-              [class.error]="registerForm.get('password')?.invalid && registerForm.get('password')?.touched">
+              [class.error]="registerForm.get('password')?.invalid && registerForm.get('password')?.touched"
+              [attr.aria-invalid]="registerForm.get('password')?.invalid && registerForm.get('password')?.touched"
+              [attr.aria-describedby]="registerForm.get('password')?.hasError('required') && registerForm.get('password')?.touched ? 'password-required' : null">
             <button 
               type="button"
               class="toggle-password"
@@ -98,7 +128,11 @@
               {{ hidePassword ? '👁️' : '🙈' }}
             </button>
           </div>
-          <div class="error-message" *ngIf="registerForm.get('password')?.hasError('required') && registerForm.get('password')?.touched">
+          <div
+            class="error-message"
+            id="password-required"
+            *ngIf="registerForm.get('password')?.hasError('required') && registerForm.get('password')?.touched"
+          >
             Le mot de passe est requis
           </div>
         </div>
@@ -107,13 +141,21 @@
         <div class="form-field">
           <label for="confirmPassword">Confirmer le mot de passe</label>
           <div class="input-group">
-            <input 
+            <input
               [type]="hideConfirmPassword ? 'password' : 'text'"
               id="confirmPassword"
               formControlName="confirmPassword"
               placeholder="Confirmez votre mot de passe"
               autocomplete="new-password"
-              [class.error]="(registerForm.get('confirmPassword')?.invalid || registerForm.hasError('passwordMismatch')) && registerForm.get('confirmPassword')?.touched">
+              [class.error]="(registerForm.get('confirmPassword')?.invalid || registerForm.hasError('passwordMismatch')) && registerForm.get('confirmPassword')?.touched"
+              [attr.aria-invalid]="(registerForm.get('confirmPassword')?.invalid || registerForm.hasError('passwordMismatch')) && registerForm.get('confirmPassword')?.touched"
+              [attr.aria-describedby]="
+                registerForm.get('confirmPassword')?.hasError('required') && registerForm.get('confirmPassword')?.touched
+                  ? 'confirm-required'
+                  : registerForm.hasError('passwordMismatch') && !registerForm.get('confirmPassword')?.hasError('required') && registerForm.get('confirmPassword')?.touched
+                    ? 'confirm-mismatch'
+                    : null
+              ">
             <button 
               type="button"
               class="toggle-password"
@@ -121,10 +163,18 @@
               {{ hideConfirmPassword ? '👁️' : '🙈' }}
             </button>
           </div>
-          <div class="error-message" *ngIf="registerForm.get('confirmPassword')?.hasError('required') && registerForm.get('confirmPassword')?.touched">
+          <div
+            class="error-message"
+            id="confirm-required"
+            *ngIf="registerForm.get('confirmPassword')?.hasError('required') && registerForm.get('confirmPassword')?.touched"
+          >
             Veuillez confirmer votre mot de passe
           </div>
-          <div class="error-message" *ngIf="registerForm.hasError('passwordMismatch') && !registerForm.get('confirmPassword')?.hasError('required') && registerForm.get('confirmPassword')?.touched">
+          <div
+            class="error-message"
+            id="confirm-mismatch"
+            *ngIf="registerForm.hasError('passwordMismatch') && !registerForm.get('confirmPassword')?.hasError('required') && registerForm.get('confirmPassword')?.touched"
+          >
             Les mots de passe ne correspondent pas
           </div>
         </div>
@@ -154,14 +204,24 @@
         <!-- Terms Checkbox -->
         <div class="terms-section">
           <label class="checkbox-label">
-            <input type="checkbox" formControlName="acceptTerms" required>
-            <span>J'accepte les 
-              <a href="/terms" target="_blank">Conditions d'utilisation</a> 
-              et la 
+            <input
+              type="checkbox"
+              formControlName="acceptTerms"
+              required
+              [attr.aria-invalid]="registerForm.get('acceptTerms')?.invalid && registerForm.get('acceptTerms')?.touched"
+              [attr.aria-describedby]="registerForm.get('acceptTerms')?.hasError('required') && registerForm.get('acceptTerms')?.touched ? 'terms-required' : null"
+            >
+            <span>J'accepte les
+              <a href="/terms" target="_blank">Conditions d'utilisation</a>
+              et la
               <a href="/privacy" target="_blank">Politique de confidentialité</a>
             </span>
           </label>
-          <div class="error-message" *ngIf="registerForm.get('acceptTerms')?.hasError('required') && registerForm.get('acceptTerms')?.touched">
+          <div
+            class="error-message"
+            id="terms-required"
+            *ngIf="registerForm.get('acceptTerms')?.hasError('required') && registerForm.get('acceptTerms')?.touched"
+          >
             Vous devez accepter les conditions d'utilisation
           </div>
         </div>

--- a/src/app/pages/help/contact-us/contact-us.component.html
+++ b/src/app/pages/help/contact-us/contact-us.component.html
@@ -49,39 +49,57 @@
 
       <div class="form-group">
         <label for="name">Name *</label>
-        <input 
-          type="text" 
-          id="name" 
+        <input
+          type="text"
+          id="name"
           formControlName="name"
           [class.error]="contactForm.get('name')?.invalid && contactForm.get('name')?.touched"
+          [attr.aria-invalid]="contactForm.get('name')?.invalid && contactForm.get('name')?.touched"
+          [attr.aria-describedby]="contactForm.get('name')?.invalid && contactForm.get('name')?.touched ? 'contact-name-error' : null"
         >
-        <span class="error-message" *ngIf="contactForm.get('name')?.invalid && contactForm.get('name')?.touched">
+        <span
+          class="error-message"
+          id="contact-name-error"
+          *ngIf="contactForm.get('name')?.invalid && contactForm.get('name')?.touched"
+        >
           {{ getErrorMessage('name') }}
         </span>
       </div>
 
       <div class="form-group">
         <label for="email">Email *</label>
-        <input 
-          type="email" 
-          id="email" 
+        <input
+          type="email"
+          id="email"
           formControlName="email"
           [class.error]="contactForm.get('email')?.invalid && contactForm.get('email')?.touched"
+          [attr.aria-invalid]="contactForm.get('email')?.invalid && contactForm.get('email')?.touched"
+          [attr.aria-describedby]="contactForm.get('email')?.invalid && contactForm.get('email')?.touched ? 'contact-email-error' : null"
         >
-        <span class="error-message" *ngIf="contactForm.get('email')?.invalid && contactForm.get('email')?.touched">
+        <span
+          class="error-message"
+          id="contact-email-error"
+          *ngIf="contactForm.get('email')?.invalid && contactForm.get('email')?.touched"
+        >
           {{ getErrorMessage('email') }}
         </span>
       </div>
 
       <div class="form-group">
         <label for="subject">Subject *</label>
-        <input 
-          type="text" 
-          id="subject" 
+        <input
+          type="text"
+          id="subject"
           formControlName="subject"
           [class.error]="contactForm.get('subject')?.invalid && contactForm.get('subject')?.touched"
+          [attr.aria-invalid]="contactForm.get('subject')?.invalid && contactForm.get('subject')?.touched"
+          [attr.aria-describedby]="contactForm.get('subject')?.invalid && contactForm.get('subject')?.touched ? 'contact-subject-error' : null"
         >
-        <span class="error-message" *ngIf="contactForm.get('subject')?.invalid && contactForm.get('subject')?.touched">
+        <span
+          class="error-message"
+          id="contact-subject-error"
+          *ngIf="contactForm.get('subject')?.invalid && contactForm.get('subject')?.touched"
+        >
           {{ getErrorMessage('subject') }}
         </span>
       </div>
@@ -98,13 +116,19 @@
 
       <div class="form-group">
         <label for="message">Message *</label>
-        <textarea 
-          id="message" 
+        <textarea
+          id="message"
           formControlName="message"
           rows="5"
           [class.error]="contactForm.get('message')?.invalid && contactForm.get('message')?.touched"
+          [attr.aria-invalid]="contactForm.get('message')?.invalid && contactForm.get('message')?.touched"
+          [attr.aria-describedby]="contactForm.get('message')?.invalid && contactForm.get('message')?.touched ? 'contact-message-error' : null"
         ></textarea>
-        <span class="error-message" *ngIf="contactForm.get('message')?.invalid && contactForm.get('message')?.touched">
+        <span
+          class="error-message"
+          id="contact-message-error"
+          *ngIf="contactForm.get('message')?.invalid && contactForm.get('message')?.touched"
+        >
           {{ getErrorMessage('message') }}
         </span>
       </div>


### PR DESCRIPTION
## Summary
- add `aria-invalid` and `aria-describedby` bindings to login form
- improve forgot-password form a11y links
- add verification code error associations
- update register form fields with a11y bindings
- connect contact us form errors for screen readers

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684b7da20f24832e878f63d665911f54