### PR TITLE
Add dark theme toggle

### DIFF
--- a/src/app/shared/components/navbar/navbar.component.html
+++ b/src/app/shared/components/navbar/navbar.component.html
@@ -89,6 +89,7 @@
           <i class="fas fa-search"></i>
         </button>
         <input *ngIf="showSearch" type="text" class="search-input" placeholder="Rechercher..." />
+        <app-theme-toggle></app-theme-toggle>
       </div>
     </nav>
   </header>

--- a/src/app/shared/components/navbar/navbar.component.scss
+++ b/src/app/shared/components/navbar/navbar.component.scss
@@ -198,6 +198,10 @@
     align-items: center;
     gap: 0.5rem;
 
+    app-theme-toggle {
+      color: white;
+    }
+
     .search-btn {
       background: none;
       border: none;

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, HostListener, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
+import { ThemeToggleComponent } from '../theme-toggle/theme-toggle.component';
 import { Router, NavigationEnd } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
@@ -9,7 +10,7 @@ import { filter } from 'rxjs/operators';
 @Component({
   selector: 'app-navbar',
   standalone: true,
-  imports: [CommonModule, RouterModule, FormsModule],
+  imports: [CommonModule, RouterModule, FormsModule, ThemeToggleComponent],
   templateUrl: './navbar.component.html',
   styleUrls: ['./navbar.component.scss']
 })

--- a/src/app/shared/components/theme-toggle/theme-toggle.component.html
+++ b/src/app/shared/components/theme-toggle/theme-toggle.component.html
@@ -1,0 +1,3 @@
+<button class="theme-toggle-btn" (click)="toggleTheme()">
+  <i class="fas" [class.fa-moon]="!isDark" [class.fa-sun]="isDark"></i>
+</button>

--- a/src/app/shared/components/theme-toggle/theme-toggle.component.scss
+++ b/src/app/shared/components/theme-toggle/theme-toggle.component.scss
@@ -1,0 +1,10 @@
+.theme-toggle-btn {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/app/shared/components/theme-toggle/theme-toggle.component.ts
+++ b/src/app/shared/components/theme-toggle/theme-toggle.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-theme-toggle',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './theme-toggle.component.html',
+  styleUrls: ['./theme-toggle.component.scss']
+})
+export class ThemeToggleComponent {
+  isDark = false;
+
+  toggleTheme(): void {
+    this.isDark = !this.isDark;
+    const body = document.body;
+    if (this.isDark) {
+      body.classList.add('dark-theme');
+    } else {
+      body.classList.remove('dark-theme');
+    }
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -39,13 +39,28 @@
     --transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
     --border-radius: 8px;
     --border-radius-lg: 12px;
+
+    /* Light/Dark theme tokens */
+    --background-color: #f5f7fa;
+    --surface-color: #ffffff;
+    --text-color: var(--gray-900);
+    --background-color-dark: #1f2937;
+    --surface-color-dark: #374151;
+    --text-color-dark: var(--gray-100);
+}
+
+.dark-theme {
+    --background-color: var(--background-color-dark);
+    --surface-color: var(--surface-color-dark);
+    --text-color: var(--text-color-dark);
+    color-scheme: dark;
 }
 
 /* Styles de base globaux */
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-    background-color: #f5f7fa;
-    color: var(--gray-900);
+    background-color: var(--background-color);
+    color: var(--text-color);
     line-height: 1.6;
     font-size: 16px;
     margin: 0;
@@ -112,7 +127,7 @@ button:hover {
 }
 
 .card {
-    background: white;
+    background: var(--surface-color);
     border-radius: var(--border-radius-lg);
     box-shadow: var(--shadow);
     transition: all 0.3s ease;
@@ -248,7 +263,7 @@ label {
 }
 
 .modal-content {
-    background: white;
+    background: var(--surface-color);
     border-radius: var(--border-radius-lg);
     box-shadow: var(--shadow-xl);
     overflow: hidden;


### PR DESCRIPTION
## Summary
- extend global styles with theme variables
- support dark theme via `.dark-theme`
- create `ThemeToggleComponent`
- display the toggle in the navbar

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b7d9734b0832e997d02d347b4598f