### PR TITLE
Use environment API URL in tracking service

### DIFF
--- a/src/app/features/tracking/services/tracking.service.ts
+++ b/src/app/features/tracking/services/tracking.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from 'src/environments/environment';
 import { Observable, of, throwError } from 'rxjs';
 import { catchError, delay, map } from 'rxjs/operators';
 import { TrackingData } from '../models/tracking-data.model';
@@ -24,7 +25,7 @@ export interface PackageInfo {
   providedIn: 'root'
 })
 export class TrackingService {
-  private apiUrl = 'http://localhost:8000/api';
+  private apiUrl = environment.apiUrl;
 
   constructor(private http: HttpClient) { }
 


### PR DESCRIPTION
## Summary
- import environment config in tracking service
- use environment.apiUrl instead of hardcoded URL

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684b87ced780832ebe5e26914afe0ed0