### PR TITLE
Enable CORS in FastAPI backend

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, Depends
+from fastapi.middleware.cors import CORSMiddleware
 from .database import Base, engine
 from .routers import auth, tracking
 from .auth import get_current_user
@@ -6,6 +7,16 @@ from .auth import get_current_user
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
+
+origins = ["http://localhost:4200"]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # Inject dependency for /api/auth/me to use token validation
 app.include_router(auth.router, prefix='/api/auth')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-fastapi
+fastapi[all]
 uvicorn
 sqlalchemy
 psycopg2-binary


### PR DESCRIPTION
## Summary
- install `fastapi[all]` to get Starlette CORS middleware
- enable `CORSMiddleware` in `backend/app/main.py`

## Testing
- `pip install -r backend/requirements.txt`
- `python -m compileall backend/app`

------
https://chatgpt.com/codex/tasks/task_e_684b87db7714832e82550111d4cad5d0