### PR TITLE
Fix current user retrieval with SQLAlchemy Session.get

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -53,7 +53,7 @@ def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(
             raise credentials_exception
     except JWTError:
         raise credentials_exception
-    user = db.query(models.User).get(int(user_id))
+    user = db.get(models.User, int(user_id))
     if user is None:
         raise credentials_exception
     return user


### PR DESCRIPTION
## Summary
- update the `get_current_user` logic to use `Session.get`

## Testing
- `python -m py_compile backend/app/auth.py`


------
https://chatgpt.com/codex/tasks/task_e_684b87e7fb70832ea40a258f398b0d5b